### PR TITLE
fix: add birthday (nameCard detail API)

### DIFF
--- a/src/main/java/solverz/business_card/domain/card/response/GetCardResponse.java
+++ b/src/main/java/solverz/business_card/domain/card/response/GetCardResponse.java
@@ -1,18 +1,20 @@
 package solverz.business_card.domain.card.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
 import lombok.Builder;
 import solverz.business_card.domain.card.entity.Card;
-import solverz.business_card.domain.card.request.GetCardRequest;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Builder
 @Schema(description = "명함 세부정보 응답")
 public record GetCardResponse(
         @Schema(description = "고객 이름")
         String name,
+
+        @Schema(description = "고객 생일")
+        LocalDate birth,
 
         @Schema(description = "고객 회사명")
         String companyName,
@@ -41,6 +43,7 @@ public record GetCardResponse(
         public static GetCardResponse from(Card card) {
             return GetCardResponse.builder()
                     .name(card.getName())
+                    .birth(card.getBirth())
                     .companyName(card.getCompanyName())
                     .email(card.getEmail())
                     .phoneNumber(card.getPhoneNumber())


### PR DESCRIPTION
## 📝 작업 내용

- [x]  : 명함(namecard) 상세보기 response 시 고객 생일 추기

<img width="493" alt="image" src="https://github.com/user-attachments/assets/da844cfd-93b5-4841-968f-8a8a09e97728">

<br>

## 🙋🏿‍♂️ 코멘트
<!-- 궁금한 점이나 리뷰를 원하는 코드가 있다면 여기 명시해주세요! -->
- 추후 보안 문제 고려 후 POST method -> GET method 수정 또는 암호화 추가 여부 고려해봅시다
