### PR TITLE
fix: 명함 목록 불러오기 response에 명함 ID 추가

### DIFF
--- a/src/main/java/solverz/business_card/domain/card/response/GetCardSummaryResponse.java
+++ b/src/main/java/solverz/business_card/domain/card/response/GetCardSummaryResponse.java
@@ -7,6 +7,9 @@ import solverz.business_card.domain.card.entity.Card;
 @Builder
 @Schema(description = "명함 요약 정보 응답")
 public record GetCardSummaryResponse(
+        @Schema(description = "명함 id")
+        Long cardId,
+
         @Schema(description = "명함 이미지 주소")
         String cardImgURL,
 
@@ -21,6 +24,7 @@ public record GetCardSummaryResponse(
 ) {
         public static GetCardSummaryResponse from(Card card) {
             return GetCardSummaryResponse.builder()
+                    .cardId(card.getId())
                     .cardImgURL(card.getCardImgURL())
                     .companyName(card.getCompanyName())
                     .companyAddress(card.getCompanyAddress())


### PR DESCRIPTION
## 📝 작업 내용
<!--------- 메인 테스크 - 서브 테스크 순으로 작성해주세요!! --------->

- [x]  : 명함 목록 불러오기 API의 response에 명함 ID 추가

기존 구조
```
{
  "totalItems": 1,
  "contents": [
    {
      "cardImgURL": "string",
      "companyName": "string",
      "companyAddress": "string",
      "phoneNumber": "string"
    }
  ]
```

변경 후 구조
```
{
  "totalItems": 2,
  "contents": [
    {
      "cardId": 1,
      "cardImgURL": "card.png",
      "companyName": "company1",
      "companyAddress": "1",
      "phoneNumber": "000-0000-0000"
    },
    {
      "cardId": 2,
      "cardImgURL": "card.png",
      "companyName": "company1",
      "companyAddress": "1",
      "phoneNumber": "000-0000-0000"
    }
  ]
}
```
